### PR TITLE
[FIX] 지원 가능한 심부름 리스트 쿼리 projection arguments 에러

### DIFF
--- a/src/main/kotlin/com/daangn/errand/ErrandApplication.kt
+++ b/src/main/kotlin/com/daangn/errand/ErrandApplication.kt
@@ -2,11 +2,8 @@ package com.daangn.errand
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.annotation.EnableScheduling
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
 
 @SpringBootApplication
 @EnableScheduling


### PR DESCRIPTION
helpCount를 생성자에서 지워놓고 쿼리 프로젝션에서는 지우지 않아서 런타임에서 에러 발생.
-> helpCount 지우니 잘 됨!