### PR TITLE
[FIX] 심부름 등록 유저 프로필 안 보임 수정

### DIFF
--- a/src/main/resources/templates/errand-detail.html
+++ b/src/main/resources/templates/errand-detail.html
@@ -86,11 +86,12 @@
             <td id="ifUnexposedOrNot" th:utext="${errand.unexposed}"></td>
         </tr>
     </table>
+    <button id="makeUnexposed" type="button">미노출시키기</button>
+    <button id="makeExposed" type="button">노출 시키기</button>
+
     <div th:each="image: ${errand.images}">
         <img th:src="${image.url}" width="200px"/>
     </div>
-    <button id="makeUnexposed" type="button">미노출시키기</button>
-    <button id="makeExposed" type="button">노출 시키기</button>
 </div>
 <script>
     const origin = document.location.origin
@@ -101,11 +102,13 @@
     unexposedButton.addEventListener('click', async () => {
         const res = await fetch(`${origin}/admin/errand/${errandId}/unexposed`)
         ifUnExposedOrNotField.innerHTML = await res.text()
+        alert('게시글을 미노출했습니다.')
     })
     const exposedButton = document.getElementById("makeExposed")
     exposedButton.addEventListener('click', async () => {
         const res = await fetch(`${origin}/admin/errand/${errandId}/exposed`)
         ifUnExposedOrNotField.innerHTML = await res.text()
+        alert('게시글을 다시 노출했습니다.')
     })
 </script>
 </body>


### PR DESCRIPTION
타임리프로 태그 안에 들어가는 text를 설정해놓아서
지금까지 닉네임, 프로필사진, 매너온도가 안보였습니다 머쓱,

해결!