### PR TITLE
[REFACTOR] Redis util 구현체 분리

### DIFF
--- a/src/main/kotlin/com/daangn/errand/support/error/ErrandError.kt
+++ b/src/main/kotlin/com/daangn/errand/support/error/ErrandError.kt
@@ -14,16 +14,5 @@ enum class ErrandError(var description: String, val status: HttpStatus) {
     AWS_ERROR("AWS 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     CUSTOM_ERROR("", HttpStatus.INTERNAL_SERVER_ERROR),
     UNEXPOSED_ERRAND("미노출된 게시물입니다.", HttpStatus.BAD_REQUEST),
-    DAANGN_ERROR("", HttpStatus.INTERNAL_SERVER_ERROR);
-    // 발생하는 예외가 무엇인지 모를 때 사용
-    fun setDescExceptionMsg(e: Exception): ErrandError {
-        description = e.toString()
-        return this
-    }
-
-    // 임의로 에러메시지를 수정하고 싶을 때 사용
-    fun setCustomDesc(msg: String): ErrandError {
-        description = msg
-        return this
-    }
+    DAANGN_ERROR("당근 API 에러", HttpStatus.INTERNAL_SERVER_ERROR);
 }

--- a/src/main/kotlin/com/daangn/errand/support/error/ErrandError.kt
+++ b/src/main/kotlin/com/daangn/errand/support/error/ErrandError.kt
@@ -12,7 +12,7 @@ enum class ErrandError(var description: String, val status: HttpStatus) {
     UNEXPECTED_VALUE("예상하지 못한 값입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     FAIL_TO_LOGIN("로그인 실패", HttpStatus.FORBIDDEN),
     AWS_ERROR("AWS 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    CUSTOM_ERROR("", HttpStatus.INTERNAL_SERVER_ERROR),
+    UNEXPECTED_ERROR("서버 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     UNEXPOSED_ERRAND("미노출된 게시물입니다.", HttpStatus.BAD_REQUEST),
     DAANGN_ERROR("당근 API 에러", HttpStatus.INTERNAL_SERVER_ERROR);
 }

--- a/src/main/kotlin/com/daangn/errand/support/exception/ErrandException.kt
+++ b/src/main/kotlin/com/daangn/errand/support/exception/ErrandException.kt
@@ -3,7 +3,7 @@ package com.daangn.errand.support.exception
 import com.daangn.errand.support.error.ErrandError
 
 class ErrandException: RuntimeException {
-    var error: ErrandError = ErrandError.CUSTOM_ERROR
+    var error: ErrandError = ErrandError.UNEXPECTED_ERROR
 
     constructor(error: ErrandError): super(error.description) { this.error = error }
     constructor(error: ErrandError, message: String): super(error.description + "($message)") { this.error = error }

--- a/src/main/kotlin/com/daangn/errand/util/RedisUtil.kt
+++ b/src/main/kotlin/com/daangn/errand/util/RedisUtil.kt
@@ -1,22 +1,6 @@
 package com.daangn.errand.util
 
-import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.stereotype.Component
-import java.time.Duration
-
-@Component
-class RedisUtil(
-    val redisTemplate: RedisTemplate<String, String>
-) {
-
-    fun getDaangnIdListByRegionId(regionId: String): List<String> {
-        val allKeys = redisTemplate.keys("$regionId*")
-        return allKeys.asSequence().map { key -> key.split(":")[1] }.toList()
-    }
-
-    fun createOrUpdateUserRegion(daangnId: String, regionId: String) {
-        val allKeys = redisTemplate.keys("*:$daangnId")
-        redisTemplate.delete(allKeys)
-        redisTemplate.opsForValue().set("$regionId:$daangnId", "", Duration.ofDays(7))
-    }
+interface RedisUtil {
+    fun getDaangnIdListByRegionId(regionId: String): List<String>
+    fun createOrUpdateUserRegion(daangnId: String, regionId: String)
 }

--- a/src/main/kotlin/com/daangn/errand/util/RedisUtilImpl.kt
+++ b/src/main/kotlin/com/daangn/errand/util/RedisUtilImpl.kt
@@ -1,0 +1,22 @@
+package com.daangn.errand.util
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class RedisUtilImpl(
+    val redisTemplate: RedisTemplate<String, String>
+): RedisUtil {
+
+    override fun getDaangnIdListByRegionId(regionId: String): List<String> {
+        val allKeys = redisTemplate.keys("$regionId*")
+        return allKeys.asSequence().map { key -> key.split(":")[1] }.toList()
+    }
+
+    override fun createOrUpdateUserRegion(daangnId: String, regionId: String) {
+        val allKeys = redisTemplate.keys("*:$daangnId")
+        redisTemplate.delete(allKeys)
+        redisTemplate.opsForValue().set("$regionId:$daangnId", "", Duration.ofDays(7))
+    }
+}

--- a/src/main/kotlin/com/daangn/errand/util/daangnUtil/DaangnUtilImpl.kt
+++ b/src/main/kotlin/com/daangn/errand/util/daangnUtil/DaangnUtilImpl.kt
@@ -56,7 +56,7 @@ class DaangnUtilImpl(
         return try {
             objectMapper.readValue(responseBody, GetAccessTokenRes::class.java)
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.CUSTOM_ERROR, e.toString())
+            throw ErrandException(ErrandError.UNEXPECTED_ERROR, e.toString())
         }
     }
 
@@ -81,7 +81,7 @@ class DaangnUtilImpl(
         return try {
             objectMapper.readValue(httpResponse.body?.string(), GetUserProfileRes::class.java).data
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.CUSTOM_ERROR, e.toString())
+            throw ErrandException(ErrandError.UNEXPECTED_ERROR, e.toString())
         }
     }
 
@@ -107,7 +107,7 @@ class DaangnUtilImpl(
         return try {
             objectMapper.readValue(responseBody, GetRegionInfoRes::class.java).data
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.CUSTOM_ERROR, e.toString())
+            throw ErrandException(ErrandError.UNEXPECTED_ERROR, e.toString())
         }
 
     }
@@ -152,7 +152,7 @@ class DaangnUtilImpl(
         return try {
             objectMapper.readValue(responseBody, GetNeighborRegionInfoRes::class.java)
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.CUSTOM_ERROR, e.toString())
+            throw ErrandException(ErrandError.UNEXPECTED_ERROR, e.toString())
         }
     }
 

--- a/src/main/kotlin/com/daangn/errand/util/daangnUtil/DaangnUtilImpl.kt
+++ b/src/main/kotlin/com/daangn/errand/util/daangnUtil/DaangnUtilImpl.kt
@@ -47,7 +47,7 @@ class DaangnUtilImpl(
         val httpResponse = try {
             httpClient.newCall(request).execute()
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.DAANGN_ERROR.setDescExceptionMsg(e))
+            throw ErrandException(ErrandError.DAANGN_ERROR, e.toString())
         }
         val responseBody: String? = httpResponse.body?.string()
         if (!httpResponse.isSuccessful) {
@@ -56,7 +56,7 @@ class DaangnUtilImpl(
         return try {
             objectMapper.readValue(responseBody, GetAccessTokenRes::class.java)
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.CUSTOM_ERROR.setDescExceptionMsg(e))
+            throw ErrandException(ErrandError.CUSTOM_ERROR, e.toString())
         }
     }
 
@@ -73,15 +73,15 @@ class DaangnUtilImpl(
                     .build()
             ).execute()
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.DAANGN_ERROR.setDescExceptionMsg(e))
+            throw ErrandException(ErrandError.DAANGN_ERROR, e.toString())
         }
         if (!httpResponse.isSuccessful) {
-            throw ErrandException(ErrandError.DAANGN_ERROR.setCustomDesc("당근 프로필 정보 조회 실패"))
+            throw ErrandException(ErrandError.DAANGN_ERROR, "당근 프로필 정보 조회 실패")
         }
         return try {
             objectMapper.readValue(httpResponse.body?.string(), GetUserProfileRes::class.java).data
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.CUSTOM_ERROR.setDescExceptionMsg(e))
+            throw ErrandException(ErrandError.CUSTOM_ERROR, e.toString())
         }
     }
 
@@ -98,16 +98,16 @@ class DaangnUtilImpl(
                     .build()
             ).execute()
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.DAANGN_ERROR.setDescExceptionMsg(e))
+            throw ErrandException(ErrandError.DAANGN_ERROR, e.toString())
         }
         val responseBody: String? = httpResponse.body?.string()
         if (!httpResponse.isSuccessful) {
-            throw ErrandException(ErrandError.DAANGN_ERROR.setCustomDesc("당근 지역 정보 조회 실패"))
+            throw ErrandException(ErrandError.DAANGN_ERROR, "당근 지역 정보 조회 실패")
         }
         return try {
             objectMapper.readValue(responseBody, GetRegionInfoRes::class.java).data
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.CUSTOM_ERROR.setDescExceptionMsg(e))
+            throw ErrandException(ErrandError.CUSTOM_ERROR, e.toString())
         }
 
     }
@@ -126,10 +126,10 @@ class DaangnUtilImpl(
         val response = try {
             httpClient.newCall(request).execute()
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.DAANGN_ERROR.setDescExceptionMsg(e))
+            throw ErrandException(ErrandError.DAANGN_ERROR, e.toString())
         }
         if (!response.isSuccessful) {
-            throw ErrandException(ErrandError.DAANGN_ERROR.setCustomDesc("당근 비즈 채팅 보내기 실패"))
+            throw ErrandException(ErrandError.DAANGN_ERROR, "당근 비즈 채팅 보내기 실패")
         }
     }
 
@@ -146,13 +146,13 @@ class DaangnUtilImpl(
         val httpResponse = try {
             httpClient.newCall(request).execute()
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.DAANGN_ERROR.setDescExceptionMsg(e))
+            throw ErrandException(ErrandError.DAANGN_ERROR, e.toString())
         }
         val responseBody: String? = httpResponse.body?.string()
         return try {
             objectMapper.readValue(responseBody, GetNeighborRegionInfoRes::class.java)
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.CUSTOM_ERROR.setDescExceptionMsg(e))
+            throw ErrandException(ErrandError.CUSTOM_ERROR, e.toString())
         }
     }
 
@@ -178,7 +178,7 @@ class DaangnUtilImpl(
         val httpResponse = try {
             httpClient.newCall(request).execute()
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.DAANGN_ERROR, e.localizedMessage)
+            throw ErrandException(ErrandError.DAANGN_ERROR, e.toString())
         }
         val responseBody: String? = httpResponse.body?.string()
         return objectMapper.readValue(responseBody, GetUserInfoByUserIdRes::class.java)
@@ -198,7 +198,7 @@ class DaangnUtilImpl(
         val httpResponse = try {
             httpClient.newCall(request).execute()
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.DAANGN_ERROR, e.localizedMessage)
+            throw ErrandException(ErrandError.DAANGN_ERROR, e.toString())
         }
         val responseBody: String? = httpResponse.body?.string()
         return objectMapper.readValue(responseBody, GetUserInfoByUserIdListRes::class.java)

--- a/src/test/kotlin/com/daangn/errand/support/error/ErrandErrorTest.kt
+++ b/src/test/kotlin/com/daangn/errand/support/error/ErrandErrorTest.kt
@@ -12,7 +12,7 @@ internal class ErrandErrorTest {
             val nullValue: String = null!!
             println(nullValue)
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.CUSTOM_ERROR, e.toString())
+            throw ErrandException(ErrandError.UNEXPECTED_ERROR, e.toString())
         }
     }
 
@@ -21,8 +21,7 @@ internal class ErrandErrorTest {
         val thrown: ErrandException = assertThrows(ErrandException::class.java) {
             throwNullPointerException()
         }
-        println(thrown.message)
 
-        Assertions.assertThat(thrown.message).isEqualTo("java.lang.NullPointerException")
+        Assertions.assertThat(thrown.message).isEqualTo("서버 에러입니다.(java.lang.NullPointerException)")
     }
 }

--- a/src/test/kotlin/com/daangn/errand/support/error/ErrandErrorTest.kt
+++ b/src/test/kotlin/com/daangn/errand/support/error/ErrandErrorTest.kt
@@ -12,7 +12,7 @@ internal class ErrandErrorTest {
             val nullValue: String = null!!
             println(nullValue)
         } catch (e: Exception) {
-            throw ErrandException(ErrandError.CUSTOM_ERROR.setDescExceptionMsg(e))
+            throw ErrandException(ErrandError.CUSTOM_ERROR, e.toString())
         }
     }
 
@@ -22,6 +22,7 @@ internal class ErrandErrorTest {
             throwNullPointerException()
         }
         println(thrown.message)
+
         Assertions.assertThat(thrown.message).isEqualTo("java.lang.NullPointerException")
     }
 }

--- a/src/test/kotlin/com/daangn/errand/util/RedisUtilTest.kt
+++ b/src/test/kotlin/com/daangn/errand/util/RedisUtilTest.kt
@@ -9,10 +9,10 @@ import org.springframework.data.redis.core.RedisTemplate
 
 @SpringBootTest
 @EnabledIfEnvironmentVariable(
-    named="SPRING_PROFILES_ACTIVE",
-    matches="local"
+    named = "SPRING_PROFILES_ACTIVE",
+    matches = "local"
 )
-internal class RedisUtilTest constructor(
+class RedisUtilTest constructor(
     @Autowired val redisTemplate: RedisTemplate<String, String>,
     @Autowired val redisUtil: RedisUtil
 ) {
@@ -35,18 +35,18 @@ internal class RedisUtilTest constructor(
     @Test
     fun getUsersByRegionId() {
         // given
-        val user1Id = "8a190fa9bb5d4d89b3944dc8c5b3a102test"
-        val user2Id = "8a190fa9bb5d4d89b3944dc8c5b3a103test"
-        val regionId = "6530459d189b"
+        val user1Id = "8a190fa9bb5d4d89b3944dc8c5b3a102"
+        val user2Id = "8a190fa9bb5d4d89b3944dc8c5b3a103"
+        val regionId = "test-region-id"
         redisTemplate.opsForValue().set("$regionId:$user1Id", "")
         redisTemplate.opsForValue().set("$regionId:$user2Id", "")
 
         // when
-        val userRegions = redisUtil.getDaangnIdListByRegionId("6530459d189b")
+        val daangnIdList = redisUtil.getDaangnIdListByRegionId(regionId)
 
         // then
-        Assertions.assertThat(userRegions.size).isEqualTo(2)
+        Assertions.assertThat(daangnIdList.size).isEqualTo(2)
 
-        redisTemplate.delete(redisTemplate.keys("*test"))
+        redisTemplate.delete(redisTemplate.keys("test*"))
     }
 }


### PR DESCRIPTION
- redis util 인터페이스 만들고 구현체 분리
- redis util test 시 지역아이디는 테스트 용으로 바꿔줌
- 사용하지 않는 에러 클래스메서드 지움
- 위 메서드에 해당하는 심부름에러 테스트 수정